### PR TITLE
bump deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,20 +8,20 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1.20.0", features = ["fs", "macros"] }
-tokio-util = { version = "0.7", features = ["io"] }
-tower = { version = "0.4" }
-reqwest = { version = "0.11", default-features = false, features = [
+chrono = { version = "0.4.38", features = ["serde"] }
+tokio = { version = "1.39.3", features = ["fs", "macros"] }
+tokio-util = { version = "0.7.11", features = ["io"] }
+tower = { version = "0.5.0" }
+reqwest = { version = "0.12.7", default-features = false, features = [
     "json",
     "rustls-tls",
     "stream",
     "multipart",
 ] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-snafu = "0.7"
-validator = { version = "0.16", features = ["derive"] }
+serde = { version = "1.0.208", features = ["derive"] }
+serde_json = "1.0.125"
+snafu = "0.8.4"
+validator = { version = "0.18.1", features = ["derive"] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
- Bump deps to latest where possible.
- Respect https://doc.rust-lang.org/cargo/reference/resolver.html#recommendations, in particular:
  > Specify all three components with the version you are currently using. This helps set the minimum version that will be used, and ensures that other users won’t end up with an older version of the dependency that might be missing something that your package requires.
- This PR intentionally does not bump `mockito` as it will require notable source changes.