### PR TITLE
bump mockito

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ validator = { version = "0.18.1", features = ["derive"] }
 
 
 [dev-dependencies]
-mockito = "0.31"
+mockito = "1.5.0"

--- a/tests/artifact_versions.rs
+++ b/tests/artifact_versions.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::artifact_versions::{
     CreateArtifactVersionParams, GetArtifactVersionParams, UpdateArtifactVersionParams,
@@ -13,6 +13,7 @@ use serde_json::json;
 
 #[tokio::test]
 async fn create_artifact_version() {
+    let mut server = Server::new_async().await;
     let expected_artifact_prn = "artifact_prn";
     let expected_custom_metadata = json!({ "foo": "bar" });
     let expected_description = "description";
@@ -20,15 +21,17 @@ async fn create_artifact_version() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*format!("/artifact_versions"))
+    let m = server
+        .mock("POST", &*format!("/artifact_versions"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/artifact-versions-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateArtifactVersionParams {
         artifact_prn: expected_artifact_prn.to_string(),
@@ -59,15 +62,17 @@ async fn create_artifact_version() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 
     let expected_custom_metadata = json!({ "foo": "a".repeat(1_000_000 ) });
 
-    let m = mock("POST", &*format!("/artifact_versions"))
+    let m = server
+        .mock("POST", &*format!("/artifact_versions"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/artifact-versions-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateArtifactVersionParams {
         artifact_prn: expected_artifact_prn.to_string(),
@@ -88,6 +93,7 @@ async fn create_artifact_version() {
 
 #[tokio::test]
 async fn get_artifact_version() {
+    let mut server = Server::new_async().await;
     let expected_prn = "prn";
     let expected_artifact_prn = "artifact_prn";
     let expected_description = "description";
@@ -95,15 +101,17 @@ async fn get_artifact_version() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/artifact_versions/{expected_prn}"))
+    let m = server
+        .mock("GET", &*format!("/artifact_versions/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/artifact-versions-get-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = GetArtifactVersionParams {
         prn: expected_prn.to_string(),
@@ -127,26 +135,29 @@ async fn get_artifact_version() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_artifact() {
+    let mut server = Server::new_async().await;
     let expected_prn = "prn";
     let expected_custom_metadata = json!({ "foo": "bar" });
     let expected_description = "updated_description";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("PATCH", &*format!("/artifact_versions/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/artifact_versions/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/artifact-versions-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateArtifactVersionParams {
         prn: expected_prn.to_string(),
@@ -168,15 +179,17 @@ async fn update_artifact() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 
     let expected_custom_metadata = json!({ "foo": "a".repeat(1_000_000 ) });
 
-    let m = mock("PATCH", &*format!("/artifact_versions/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/artifact_versions/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/artifact-versions-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateArtifactVersionParams {
         prn: expected_prn.to_string(),

--- a/tests/artifacts.rs
+++ b/tests/artifacts.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::artifacts::{CreateArtifactParams, GetArtifactParams, UpdateArtifactParams};
 
@@ -10,6 +10,7 @@ use serde_json::json;
 
 #[tokio::test]
 async fn create_artifact() {
+    let mut server = Server::new_async().await;
     let expected_custom_metadata = json!({ "foo": "bar" });
     let expected_description = "test";
     let expected_name = "a";
@@ -17,15 +18,17 @@ async fn create_artifact() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*format!("/artifacts"))
+    let m = server
+        .mock("POST", &*format!("/artifacts"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/artifacts-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateArtifactParams {
         custom_metadata: Some(expected_custom_metadata.as_object().unwrap().clone()),
@@ -53,15 +56,17 @@ async fn create_artifact() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 
     let expected_custom_metadata = json!({ "foo": "a".repeat(1_000_000 ) });
 
-    let m = mock("POST", &*format!("/artifacts"))
+    let m = server
+        .mock("POST", &*format!("/artifacts"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/artifacts-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateArtifactParams {
         custom_metadata: Some(expected_custom_metadata.as_object().unwrap().clone()),
@@ -82,6 +87,7 @@ async fn create_artifact() {
 
 #[tokio::test]
 async fn get_artifact() {
+    let mut server = Server::new_async().await;
     let expected_description = "test";
     let expected_name = "a";
     let expected_organization_prn = "string";
@@ -89,15 +95,17 @@ async fn get_artifact() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/artifacts/{expected_prn}"))
+    let m = server
+        .mock("GET", &*format!("/artifacts/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/artifacts-get-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = GetArtifactParams {
         prn: expected_prn.to_string(),
@@ -118,11 +126,12 @@ async fn get_artifact() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_artifact() {
+    let mut server = Server::new_async().await;
     let expected_custom_metadata = json!({ "foo": "bar" });
     let expected_description = "test-update";
     let expected_name = "b";
@@ -131,15 +140,17 @@ async fn update_artifact() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("PATCH", &*format!("/artifacts/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/artifacts/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/artifacts-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateArtifactParams {
         prn: expected_prn.to_string(),
@@ -167,15 +178,17 @@ async fn update_artifact() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 
     let expected_custom_metadata = json!({ "foo": "a".repeat(1_000_000 ) });
 
-    let m = mock("PATCH", &*format!("/artifacts/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/artifacts/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/artifacts-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateArtifactParams {
         prn: expected_prn.to_string(),

--- a/tests/binaries.rs
+++ b/tests/binaries.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::binaries::{
     BinaryState, CreateBinaryParams, GetBinaryParams, UpdateBinaryParams,
@@ -13,6 +13,7 @@ use serde_json::json;
 
 #[tokio::test]
 async fn create_binary() {
+    let mut server = Server::new_async().await;
     let expected_artifact_version_prn = "artifact_version_prn";
     let expected_custom_metadata = json!({ "foo": "bar" });
     let expected_description = "description";
@@ -23,15 +24,17 @@ async fn create_binary() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*format!("/binaries"))
+    let m = server
+        .mock("POST", &*format!("/binaries"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/binaries-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateBinaryParams {
         artifact_version_prn: expected_artifact_version_prn.to_string(),
@@ -67,15 +70,17 @@ async fn create_binary() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 
     let expected_custom_metadata = json!({ "foo": "a".repeat(1_000_000 ) });
 
-    let m = mock("POST", &*format!("/binaries"))
+    let m = server
+        .mock("POST", &*format!("/binaries"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/binaries-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateBinaryParams {
         artifact_version_prn: expected_artifact_version_prn.to_string(),
@@ -98,6 +103,7 @@ async fn create_binary() {
 
 #[tokio::test]
 async fn get_binary() {
+    let mut server = Server::new_async().await;
     let expected_prn = "prn";
     let expected_artifact_version_prn = "artifact_version_prn";
     let expected_description = "description";
@@ -108,15 +114,17 @@ async fn get_binary() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/binaries/{expected_prn}"))
+    let m = server
+        .mock("GET", &*format!("/binaries/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/binaries-get-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = GetBinaryParams {
         prn: expected_prn.to_string(),
@@ -143,11 +151,12 @@ async fn get_binary() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_binary() {
+    let mut server = Server::new_async().await;
     let expected_artifact_version_prn = "artifact_version_prn";
     let expected_custom_metadata = json!({ "foo": "bar" });
     let expected_description = "description";
@@ -159,15 +168,17 @@ async fn update_binary() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("PATCH", &*format!("/binaries/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/binaries/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/binaries-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateBinaryParams {
         prn: expected_prn.to_string(),
@@ -203,15 +214,17 @@ async fn update_binary() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 
     let expected_custom_metadata = json!({ "foo": "a".repeat(1_000_000 ) });
 
-    let m = mock("PATCH", &*format!("/binaries/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/binaries/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/binaries-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateBinaryParams {
         prn: expected_prn.to_string(),

--- a/tests/bundles.rs
+++ b/tests/bundles.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::bundles::{CreateBundleParams, GetBundleParams, UpdateBundleParams};
 
@@ -10,6 +10,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_bundle() {
+    let mut server = Server::new_async().await;
     let expected_organization_prn = "organization_prn";
     let expected_artifact_versions = [
         "artifact_version_prn_1".to_string(),
@@ -20,15 +21,17 @@ async fn create_bundle() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", "/bundles")
+    let m = server
+        .mock("POST", "/bundles")
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/bundles-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateBundleParams {
         organization_prn: expected_organization_prn.to_string(),
@@ -48,11 +51,12 @@ async fn create_bundle() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_bundle() {
+    let mut server = Server::new_async().await;
     let expected_prn = "prn";
     let expected_organization_prn = "organization_prn";
     let expected_artifact_versions = [
@@ -63,15 +67,17 @@ async fn get_bundle() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/bundles/{expected_prn}"))
+    let m = server
+        .mock("GET", &*format!("/bundles/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/bundles-get-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = GetBundleParams {
         prn: expected_prn.to_string(),
@@ -89,25 +95,28 @@ async fn get_bundle() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_bundle() {
+    let mut server = Server::new_async().await;
     let expected_name = "b";
     let expected_prn = "1";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("PATCH", &*format!("/bundles/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/bundles/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/bundles-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateBundleParams {
         prn: expected_prn.to_string(),
@@ -121,5 +130,5 @@ async fn update_bundle() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/ca_certificates.rs
+++ b/tests/ca_certificates.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::ca_certificates::{
     CaCertificateJitp, CreateCaCertificateParams, CreateVerificationCodeParams,
@@ -13,6 +13,7 @@ use peridio_sdk::api::{Api, ApiOptions};
 
 #[tokio::test]
 async fn create_ca_certificate() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let certificate = "cert-base-64";
     let verification_certificate = "verification_cert-base-64";
@@ -26,18 +27,20 @@ async fn create_ca_certificate() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "POST",
-        &*format!("/orgs/{organization_name}/ca_certificates"),
-    )
-    .with_status(201)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/ca-certificates-create-201.json")
-    .create();
+    let m = server
+        .mock(
+            "POST",
+            &*format!("/orgs/{organization_name}/ca_certificates"),
+        )
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/ca-certificates-create-201.json")
+        .create_async()
+        .await;
 
     let jitp = CaCertificateJitp {
         description: jitp_description.to_string(),
@@ -70,27 +73,30 @@ async fn create_ca_certificate() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn delete_ca_certificate() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let ca_certificate_serial = "ABCD-1234";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "DELETE",
-        &*format!("/orgs/{organization_name}/ca_certificates/{ca_certificate_serial}"),
-    )
-    .with_status(204)
-    .with_body("")
-    .create();
+    let m = server
+        .mock(
+            "DELETE",
+            &*format!("/orgs/{organization_name}/ca_certificates/{ca_certificate_serial}"),
+        )
+        .with_status(204)
+        .with_body("")
+        .create_async()
+        .await;
 
     let params = DeleteCaCertificateParams {
         organization_name: organization_name.to_string(),
@@ -102,11 +108,12 @@ async fn delete_ca_certificate() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_ca_certificate() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let ca_certificate_serial = "serial";
 
@@ -114,18 +121,20 @@ async fn get_ca_certificate() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/ca_certificates/{ca_certificate_serial}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/ca-certificates-get-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!("/orgs/{organization_name}/ca_certificates/{ca_certificate_serial}"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/ca-certificates-get-200.json")
+        .create_async()
+        .await;
 
     let params = GetCaCertificateParams {
         organization_name: organization_name.to_string(),
@@ -146,11 +155,12 @@ async fn get_ca_certificate() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn list_ca_certificate() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
 
     let expected_description_0 = "test-0";
@@ -161,18 +171,20 @@ async fn list_ca_certificate() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/ca_certificates"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/ca-certificates-list-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!("/orgs/{organization_name}/ca_certificates"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/ca-certificates-list-200.json")
+        .create_async()
+        .await;
 
     let params = ListCaCertificateParams {
         organization_name: organization_name.to_string(),
@@ -197,29 +209,32 @@ async fn list_ca_certificate() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn create_ca_verification_code() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
 
     let expected_verification_id = "test";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "POST",
-        &*format!("/orgs/{organization_name}/ca_certificates/verification_codes"),
-    )
-    .with_status(201)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/ca-certificates-verification-code-create-201.json")
-    .create();
+    let m = server
+        .mock(
+            "POST",
+            &*format!("/orgs/{organization_name}/ca_certificates/verification_codes"),
+        )
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/ca-certificates-verification-code-create-201.json")
+        .create_async()
+        .await;
 
     let params = CreateVerificationCodeParams {
         organization_name: organization_name.to_string(),
@@ -240,11 +255,12 @@ async fn create_ca_verification_code() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_ca_certificate() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let ca_certificate_serial = "serial";
     let jitp_description = "jitp-test";
@@ -257,18 +273,20 @@ async fn update_ca_certificate() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "PUT",
-        &*format!("/orgs/{organization_name}/ca_certificates/{ca_certificate_serial}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/ca-certificates-update-200.json")
-    .create();
+    let m = server
+        .mock(
+            "PUT",
+            &*format!("/orgs/{organization_name}/ca_certificates/{ca_certificate_serial}"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/ca-certificates-update-200.json")
+        .create_async()
+        .await;
 
     let jitp = CaCertificateJitp {
         description: jitp_description.to_string(),
@@ -298,5 +316,5 @@ async fn update_ca_certificate() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/cohorts.rs
+++ b/tests/cohorts.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::cohorts::{CreateCohortParams, GetCohortParams, UpdateCohortParams};
 
@@ -10,6 +10,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_cohort() {
+    let mut server = Server::new_async().await;
     let expected_description = "string";
     let expected_name = "a";
     let expected_organization_prn = "1";
@@ -17,15 +18,17 @@ async fn create_cohort() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*format!("/cohorts"))
+    let m = server
+        .mock("POST", &*format!("/cohorts"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/cohorts-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateCohortParams {
         description: Some(expected_description.to_string()),
@@ -50,11 +53,12 @@ async fn create_cohort() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_cohort() {
+    let mut server = Server::new_async().await;
     let expected_description = "string";
     let expected_name = "a";
     let expected_organization_prn = "1";
@@ -62,15 +66,17 @@ async fn get_cohort() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/cohorts/{expected_prn}"))
+    let m = server
+        .mock("GET", &*format!("/cohorts/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/cohorts-get-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = GetCohortParams {
         prn: expected_prn.to_string(),
@@ -91,11 +97,12 @@ async fn get_cohort() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_cohort() {
+    let mut server = Server::new_async().await;
     let expected_description = "string";
     let expected_name = "a";
     let expected_organization_prn = "1";
@@ -103,15 +110,17 @@ async fn update_cohort() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("PATCH", &*format!("/cohorts/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/cohorts/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/cohorts-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateCohortParams {
         prn: expected_prn.to_string(),
@@ -134,5 +143,5 @@ async fn update_cohort() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/deployments.rs
+++ b/tests/deployments.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::deployments::{
     CreateDeploymentParams, DeleteDeploymentParams, DeploymentCondition, GetDeploymentParams,
@@ -13,6 +13,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_deployment() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
 
     let expected_conditions = DeploymentCondition {
@@ -28,18 +29,20 @@ async fn create_deployment() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "POST",
-        &*format!("/orgs/{organization_name}/products/{expected_product}/deployments"),
-    )
-    .with_status(201)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/deployments-create-201.json")
-    .create();
+    let m = server
+        .mock(
+            "POST",
+            &*format!("/orgs/{organization_name}/products/{expected_product}/deployments"),
+        )
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/deployments-create-201.json")
+        .create_async()
+        .await;
 
     let params = CreateDeploymentParams {
         product_name: expected_product.to_string(),
@@ -63,30 +66,33 @@ async fn create_deployment() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn delete_deployment() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "test";
     let deployment_name = "a";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "DELETE",
-        &*format!(
-            "/orgs/{organization_name}/products/{product_name}/deployments/{deployment_name}"
-        ),
-    )
-    .with_status(204)
-    .with_body("")
-    .create();
+    let m = server
+        .mock(
+            "DELETE",
+            &*format!(
+                "/orgs/{organization_name}/products/{product_name}/deployments/{deployment_name}"
+            ),
+        )
+        .with_status(204)
+        .with_body("")
+        .create_async()
+        .await;
 
     let params = DeleteDeploymentParams {
         organization_name: organization_name.to_string(),
@@ -99,11 +105,12 @@ async fn delete_deployment() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_deployment() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let deployment_name = "a";
@@ -119,20 +126,22 @@ async fn get_deployment() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!(
-            "/orgs/{organization_name}/products/{product_name}/deployments/{deployment_name}"
-        ),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/deployments-get-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!(
+                "/orgs/{organization_name}/products/{product_name}/deployments/{deployment_name}"
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/deployments-get-200.json")
+        .create_async()
+        .await;
 
     let params = GetDeploymentParams {
         organization_name: organization_name.to_string(),
@@ -151,11 +160,12 @@ async fn get_deployment() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn list_deployments() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
 
@@ -175,18 +185,20 @@ async fn list_deployments() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/products/{product_name}/deployments"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/deployments-list-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!("/orgs/{organization_name}/products/{product_name}/deployments"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/deployments-list-200.json")
+        .create_async()
+        .await;
 
     let params = ListDeploymentParams {
         organization_name: organization_name.to_string(),
@@ -214,11 +226,12 @@ async fn list_deployments() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_deployment() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let deployment_name = "a";
 
@@ -235,20 +248,22 @@ async fn update_deployment() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "PUT",
-        &*format!(
+    let m = server
+        .mock(
+            "PUT",
+            &*format!(
             "/orgs/{organization_name}/products/{expected_product}/deployments/{deployment_name}"
         ),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/deployments-update-200.json")
-    .create();
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/deployments-update-200.json")
+        .create_async()
+        .await;
 
     let params = UpdateDeploymentParams {
         product_name: expected_product.to_string(),
@@ -278,5 +293,5 @@ async fn update_deployment() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/device_certificates.rs
+++ b/tests/device_certificates.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::device_certificates::{
     CreateDeviceCertificateParams, DeleteDeviceCertificateParams, GetDeviceCertificateParams,
@@ -13,6 +13,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_device_certificate() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let device_identifier = "dev-id-1";
@@ -24,18 +25,18 @@ async fn create_device_certificate() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
+    let m = server.mock(
         "POST",
         &*format!("/orgs/{organization_name}/products/{product_name}/devices/{device_identifier}/certificates"),
     )
     .with_status(201)
     .with_header("content-type", "application/json")
     .with_body_from_file("tests/fixtures/device-certificates-create-201.json")
-    .create();
+    .create_async().await;
 
     let params = CreateDeviceCertificateParams {
         product_name: product_name.to_string(),
@@ -53,11 +54,12 @@ async fn create_device_certificate() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn delete_device_certificate() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let device_identifier = "a";
@@ -65,17 +67,17 @@ async fn delete_device_certificate() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
+    let m = server.mock(
         "DELETE",
         &*format!("/orgs/{organization_name}/products/{product_name}/devices/{device_identifier}/certificates/{certificate_serial}"),
     )
     .with_status(204)
     .with_body("")
-    .create();
+    .create_async().await;
 
     let params = DeleteDeviceCertificateParams {
         organization_name: organization_name.to_string(),
@@ -89,11 +91,12 @@ async fn delete_device_certificate() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_device_certificate() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let device_identifier = "a";
@@ -105,18 +108,18 @@ async fn get_device_certificate() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
+    let m = server.mock(
         "GET",
         &*format!("/orgs/{organization_name}/products/{product_name}/devices/{device_identifier}/certificates/{certificate_serial}"),
     )
     .with_status(200)
     .with_header("content-type", "application/json")
     .with_body_from_file("tests/fixtures/device-certificates-get-200.json")
-    .create();
+    .create_async().await;
 
     let params = GetDeviceCertificateParams {
         organization_name: organization_name.to_string(),
@@ -134,11 +137,12 @@ async fn get_device_certificate() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn list_device_certificate() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let device_identifier = "a";
@@ -153,18 +157,18 @@ async fn list_device_certificate() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
+    let m = server.mock(
         "GET",
         &*format!("/orgs/{organization_name}/products/{product_name}/devices/{device_identifier}/certificates"),
     )
     .with_status(200)
     .with_header("content-type", "application/json")
     .with_body_from_file("tests/fixtures/device-certificates-list-200.json")
-    .create();
+    .create_async().await;
 
     let params = ListDeviceCertificateParams {
         organization_name: organization_name.to_string(),
@@ -187,5 +191,5 @@ async fn list_device_certificate() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::devices::{
     AuthenticateDeviceParams, CreateDeviceParams, DeleteDeviceParams, GetDeviceParams,
@@ -13,6 +13,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_device() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
 
@@ -26,18 +27,20 @@ async fn create_device() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "POST",
-        &*format!("/orgs/{organization_name}/products/{product_name}/devices"),
-    )
-    .with_status(201)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/devices-create-201.json")
-    .create();
+    let m = server
+        .mock(
+            "POST",
+            &*format!("/orgs/{organization_name}/products/{product_name}/devices"),
+        )
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/devices-create-201.json")
+        .create_async()
+        .await;
 
     let params = CreateDeviceParams {
         product_name: product_name.to_string(),
@@ -65,28 +68,33 @@ async fn create_device() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn delete_device() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let device_identifier = "a";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "DELETE",
-        &*format!("/orgs/{organization_name}/products/{product_name}/devices/{device_identifier}"),
-    )
-    .with_status(204)
-    .with_body("")
-    .create();
+    let m = server
+        .mock(
+            "DELETE",
+            &*format!(
+                "/orgs/{organization_name}/products/{product_name}/devices/{device_identifier}"
+            ),
+        )
+        .with_status(204)
+        .with_body("")
+        .create_async()
+        .await;
 
     let params = DeleteDeviceParams {
         organization_name: organization_name.to_string(),
@@ -99,11 +107,12 @@ async fn delete_device() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_device() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let device_identifier = "a";
@@ -115,18 +124,22 @@ async fn get_device() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/products/{product_name}/devices/{device_identifier}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/devices-get-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!(
+                "/orgs/{organization_name}/products/{product_name}/devices/{device_identifier}"
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/devices-get-200.json")
+        .create_async()
+        .await;
 
     let params = GetDeviceParams {
         organization_name: organization_name.to_string(),
@@ -147,11 +160,12 @@ async fn get_device() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn list_device() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
 
@@ -165,18 +179,20 @@ async fn list_device() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/products/{product_name}/devices"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/devices-list-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!("/orgs/{organization_name}/products/{product_name}/devices"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/devices-list-200.json")
+        .create_async()
+        .await;
 
     let params = ListDeviceParams {
         organization_name: organization_name.to_string(),
@@ -204,11 +220,12 @@ async fn list_device() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_device() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let device_identifier = "a";
@@ -220,18 +237,22 @@ async fn update_device() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "PUT",
-        &*format!("/orgs/{organization_name}/products/{product_name}/devices/{device_identifier}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/devices-update-200.json")
-    .create();
+    let m = server
+        .mock(
+            "PUT",
+            &*format!(
+                "/orgs/{organization_name}/products/{product_name}/devices/{device_identifier}"
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/devices-update-200.json")
+        .create_async()
+        .await;
 
     let params = UpdateDeviceParams {
         product_name: product_name.to_string(),
@@ -257,11 +278,12 @@ async fn update_device() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn authenticate_device() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let certificate = "dGVzdA==";
@@ -273,18 +295,20 @@ async fn authenticate_device() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "POST",
-        &*format!("/orgs/{organization_name}/products/{product_name}/devices/auth"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/devices-authenticate-200.json")
-    .create();
+    let m = server
+        .mock(
+            "POST",
+            &*format!("/orgs/{organization_name}/products/{product_name}/devices/auth"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/devices-authenticate-200.json")
+        .create_async()
+        .await;
 
     let params = AuthenticateDeviceParams {
         product_name: product_name.to_string(),
@@ -305,5 +329,5 @@ async fn authenticate_device() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/firmwares.rs
+++ b/tests/firmwares.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::firmwares::{
     CreateFirmwareParams, DeleteFirmwareParams, GetFirmwareParams, ListFirmwareParams,
@@ -12,6 +12,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_firmware() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let firmware = "tests/files/firmware_test";
     let ttl = 10;
@@ -28,18 +29,20 @@ async fn create_firmware() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "POST",
-        &*format!("/orgs/{organization_name}/products/{expected_product}/firmwares"),
-    )
-    .with_status(201)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/firmwares-create-201.json")
-    .create();
+    let m = server
+        .mock(
+            "POST",
+            &*format!("/orgs/{organization_name}/products/{expected_product}/firmwares"),
+        )
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/firmwares-create-201.json")
+        .create_async()
+        .await;
 
     let params = CreateFirmwareParams {
         product_name: expected_product.to_string(),
@@ -66,28 +69,33 @@ async fn create_firmware() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn delete_firmware() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "test";
     let firmware_uuid = "4dd9ff49-ec74-45fc-8558-7f98839019ec";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "DELETE",
-        &*format!("/orgs/{organization_name}/products/{product_name}/firmwares/{firmware_uuid}"),
-    )
-    .with_status(204)
-    .with_body("")
-    .create();
+    let m = server
+        .mock(
+            "DELETE",
+            &*format!(
+                "/orgs/{organization_name}/products/{product_name}/firmwares/{firmware_uuid}"
+            ),
+        )
+        .with_status(204)
+        .with_body("")
+        .create_async()
+        .await;
 
     let params = DeleteFirmwareParams {
         organization_name: organization_name.to_string(),
@@ -100,11 +108,12 @@ async fn delete_firmware() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_firmware() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "test";
     let firmware_uuid = "4dd9ff49-ec74-45fc-8558-7f98839019ec";
@@ -121,18 +130,22 @@ async fn get_firmware() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/products/{product_name}/firmwares/{firmware_uuid}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/firmwares-get-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!(
+                "/orgs/{organization_name}/products/{product_name}/firmwares/{firmware_uuid}"
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/firmwares-get-200.json")
+        .create_async()
+        .await;
 
     let params = GetFirmwareParams {
         organization_name: organization_name.to_string(),
@@ -158,11 +171,12 @@ async fn get_firmware() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn list_firmwares() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "test";
 
@@ -182,18 +196,20 @@ async fn list_firmwares() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/products/{product_name}/firmwares"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/firmwares-list-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!("/orgs/{organization_name}/products/{product_name}/firmwares"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/firmwares-list-200.json")
+        .create_async()
+        .await;
 
     let params = ListFirmwareParams {
         organization_name: organization_name.to_string(),
@@ -226,5 +242,5 @@ async fn list_firmwares() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/organization_users.rs
+++ b/tests/organization_users.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::organization_users::{
     AddOrganizationUserParams, GetOrganizationUserParams, ListOrganizationUserParams,
@@ -13,6 +13,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_organization_user() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
 
     let expected_email = "test@test.com";
@@ -21,15 +22,17 @@ async fn create_organization_user() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*format!("/orgs/{organization_name}/users"))
+    let m = server
+        .mock("POST", &*format!("/orgs/{organization_name}/users"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/organization-users-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = AddOrganizationUserParams {
         organization_name: organization_name.to_string(),
@@ -46,27 +49,30 @@ async fn create_organization_user() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn remove_organization_user() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let user_username = "usr-1";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "DELETE",
-        &*format!("/orgs/{organization_name}/users/{user_username}"),
-    )
-    .with_status(204)
-    .with_body("")
-    .create();
+    let m = server
+        .mock(
+            "DELETE",
+            &*format!("/orgs/{organization_name}/users/{user_username}"),
+        )
+        .with_status(204)
+        .with_body("")
+        .create_async()
+        .await;
 
     let params = RemoveOrganizationUserParams {
         organization_name: organization_name.to_string(),
@@ -78,11 +84,12 @@ async fn remove_organization_user() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_organization_user() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let user_username = "usr-1";
 
@@ -92,18 +99,20 @@ async fn get_organization_user() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/users/{user_username}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/organization-users-get-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!("/orgs/{organization_name}/users/{user_username}"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/organization-users-get-200.json")
+        .create_async()
+        .await;
 
     let params = GetOrganizationUserParams {
         organization_name: organization_name.to_string(),
@@ -119,11 +128,12 @@ async fn get_organization_user() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn list_organization_user() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
 
     let expected_email_0 = "test-0@test.com";
@@ -136,15 +146,17 @@ async fn list_organization_user() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/orgs/{organization_name}/users"))
+    let m = server
+        .mock("GET", &*format!("/orgs/{organization_name}/users"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/organization-users-list-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = ListOrganizationUserParams {
         organization_name: organization_name.to_string(),
@@ -165,11 +177,12 @@ async fn list_organization_user() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_organization_user() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let user_username = "usr-1";
 
@@ -179,18 +192,20 @@ async fn update_organization_user() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "PUT",
-        &*format!("/orgs/{organization_name}/users/{user_username}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/organization-users-update-200.json")
-    .create();
+    let m = server
+        .mock(
+            "PUT",
+            &*format!("/orgs/{organization_name}/users/{user_username}"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/organization-users-update-200.json")
+        .create_async()
+        .await;
 
     let params = UpdateOrganizationUserParams {
         organization_name: organization_name.to_string(),
@@ -207,5 +222,5 @@ async fn update_organization_user() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/product_users.rs
+++ b/tests/product_users.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::product_users::{
     AddProductUserParams, GetProductUserParams, ListProductUserParams, RemoveProductUserParams,
@@ -13,6 +13,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn add_product_user() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
 
@@ -22,18 +23,20 @@ async fn add_product_user() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "POST",
-        &*format!("/orgs/{organization_name}/products/{product_name}/users"),
-    )
-    .with_status(201)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/product-users-create-201.json")
-    .create();
+    let m = server
+        .mock(
+            "POST",
+            &*format!("/orgs/{organization_name}/products/{product_name}/users"),
+        )
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/product-users-create-201.json")
+        .create_async()
+        .await;
 
     let params = AddProductUserParams {
         organization_name: organization_name.to_string(),
@@ -51,28 +54,31 @@ async fn add_product_user() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn remove_product_user() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let user_username = "usr-1";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "DELETE",
-        &*format!("/orgs/{organization_name}/products/{product_name}/users/{user_username}"),
-    )
-    .with_status(204)
-    .with_body("")
-    .create();
+    let m = server
+        .mock(
+            "DELETE",
+            &*format!("/orgs/{organization_name}/products/{product_name}/users/{user_username}"),
+        )
+        .with_status(204)
+        .with_body("")
+        .create_async()
+        .await;
 
     let params = RemoveProductUserParams {
         organization_name: organization_name.to_string(),
@@ -85,11 +91,12 @@ async fn remove_product_user() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_product_user() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let user_username = "usr-1";
@@ -100,18 +107,20 @@ async fn get_product_user() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/products/{product_name}/users/{user_username}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/product-users-get-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!("/orgs/{organization_name}/products/{product_name}/users/{user_username}"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/product-users-get-200.json")
+        .create_async()
+        .await;
 
     let params = GetProductUserParams {
         organization_name: organization_name.to_string(),
@@ -128,11 +137,12 @@ async fn get_product_user() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn list_product_user() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
 
@@ -146,18 +156,20 @@ async fn list_product_user() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/products/{product_name}/users"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/product-users-list-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!("/orgs/{organization_name}/products/{product_name}/users"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/product-users-list-200.json")
+        .create_async()
+        .await;
 
     let params = ListProductUserParams {
         organization_name: organization_name.to_string(),
@@ -179,11 +191,12 @@ async fn list_product_user() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_product_user() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
     let user_username = "usr-1";
@@ -194,18 +207,20 @@ async fn update_product_user() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "PUT",
-        &*format!("/orgs/{organization_name}/products/{product_name}/users/{user_username}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/product-users-update-200.json")
-    .create();
+    let m = server
+        .mock(
+            "PUT",
+            &*format!("/orgs/{organization_name}/products/{product_name}/users/{user_username}"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/product-users-update-200.json")
+        .create_async()
+        .await;
 
     let params = UpdateProductUserParams {
         organization_name: organization_name.to_string(),
@@ -223,5 +238,5 @@ async fn update_product_user() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/products.rs
+++ b/tests/products.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::products::{
     CreateProductParams, DeleteProductParams, GetProductParams, ListProductParams, UpdateProduct,
@@ -13,21 +13,24 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_product() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
 
     let expected_name = "pro-1";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*format!("/orgs/{organization_name}/products"))
+    let m = server
+        .mock("POST", &*format!("/orgs/{organization_name}/products"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/products-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateProductParams {
         name: expected_name.to_string(),
@@ -41,27 +44,30 @@ async fn create_product() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn delete_product() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "DELETE",
-        &*format!("/orgs/{organization_name}/products/{product_name}"),
-    )
-    .with_status(204)
-    .with_body("")
-    .create();
+    let m = server
+        .mock(
+            "DELETE",
+            &*format!("/orgs/{organization_name}/products/{product_name}"),
+        )
+        .with_status(204)
+        .with_body("")
+        .create_async()
+        .await;
 
     let params = DeleteProductParams {
         organization_name: organization_name.to_string(),
@@ -73,11 +79,12 @@ async fn delete_product() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_product() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
 
@@ -85,18 +92,20 @@ async fn get_product() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "GET",
-        &*format!("/orgs/{organization_name}/products/{product_name}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/products-get-200.json")
-    .create();
+    let m = server
+        .mock(
+            "GET",
+            &*format!("/orgs/{organization_name}/products/{product_name}"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/products-get-200.json")
+        .create_async()
+        .await;
 
     let params = GetProductParams {
         organization_name: organization_name.to_string(),
@@ -110,11 +119,12 @@ async fn get_product() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn list_products() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
 
     let expected_name_0 = "pro-0";
@@ -123,15 +133,17 @@ async fn list_products() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/orgs/{organization_name}/products"))
+    let m = server
+        .mock("GET", &*format!("/orgs/{organization_name}/products"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/products-list-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = ListProductParams {
         organization_name: organization_name.to_string(),
@@ -148,11 +160,12 @@ async fn list_products() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_product() {
+    let mut server = Server::new_async().await;
     let organization_name = "org-1";
     let product_name = "pro-1";
 
@@ -160,18 +173,20 @@ async fn update_product() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock(
-        "PUT",
-        &*format!("/orgs/{organization_name}/products/{product_name}"),
-    )
-    .with_status(200)
-    .with_header("content-type", "application/json")
-    .with_body_from_file("tests/fixtures/products-update-200.json")
-    .create();
+    let m = server
+        .mock(
+            "PUT",
+            &*format!("/orgs/{organization_name}/products/{product_name}"),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body_from_file("tests/fixtures/products-update-200.json")
+        .create_async()
+        .await;
 
     let params = UpdateProductParams {
         product_name: product_name.to_string(),
@@ -188,5 +203,5 @@ async fn update_product() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/products_v2.rs
+++ b/tests/products_v2.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 use peridio_sdk::api::products_v2::CreateProductV2Params;
 use peridio_sdk::api::products_v2::GetProductV2Params;
 use peridio_sdk::api::products_v2::UpdateProductV2Params;
@@ -10,20 +10,23 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_product() {
+    let mut server = Server::new_async().await;
     let expected_name = "name";
     let expected_organization_prn = "organization_prn";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*format!("/products"))
+    let m = server
+        .mock("POST", &*format!("/products"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/products-v2-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateProductV2Params {
         archived: None,
@@ -39,25 +42,28 @@ async fn create_product() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_product() {
+    let mut server = Server::new_async().await;
     let expected_name = "name";
     let expected_prn = "prn";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/products/{expected_prn}"))
+    let m = server
+        .mock("GET", &*format!("/products/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/products-v2-get-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = GetProductV2Params {
         prn: expected_prn.to_string(),
@@ -70,26 +76,29 @@ async fn get_product() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_product() {
+    let mut server = Server::new_async().await;
     let expected_archived = true;
     let expected_name = "name";
     let expected_prn = "prn";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("PATCH", &*format!("/products/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/products/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/products-v2-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateProductV2Params {
         prn: expected_prn.to_string(),
@@ -105,5 +114,5 @@ async fn update_product() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/releases.rs
+++ b/tests/releases.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::releases::{CreateReleaseParams, GetReleaseParams, UpdateReleaseParams};
 
@@ -10,6 +10,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_release() {
+    let mut server = Server::new_async().await;
     let expected_bundle_prn = "bundle_prn";
     let expected_cohort_prn = "cohort_prn";
     let expected_description = "description";
@@ -25,15 +26,17 @@ async fn create_release() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*"/releases".to_string())
+    let m = server
+        .mock("POST", &*"/releases".to_string())
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/releases-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateReleaseParams {
         bundle_prn: expected_bundle_prn.to_string(),
@@ -85,11 +88,12 @@ async fn create_release() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_release() {
+    let mut server = Server::new_async().await;
     let expected_bundle_prn = "bundle_prn";
     let expected_cohort_prn = "cohort_prn";
     let expected_description = "description";
@@ -105,15 +109,17 @@ async fn get_release() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/releases/{expected_prn}"))
+    let m = server
+        .mock("GET", &*format!("/releases/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/releases-get-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = GetReleaseParams {
         prn: expected_prn.to_string(),
@@ -151,11 +157,12 @@ async fn get_release() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_release() {
+    let mut server = Server::new_async().await;
     let expected_bundle_prn = "bundle_prn";
     let expected_cohort_prn = "cohort_prn";
     let expected_description = "updated_description";
@@ -171,15 +178,17 @@ async fn update_release() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("PATCH", &*format!("/releases/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/releases/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/releases-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateReleaseParams {
         prn: expected_prn.to_string(),
@@ -228,5 +237,5 @@ async fn update_release() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/signing_keys.rs
+++ b/tests/signing_keys.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::signing_keys::{
     CreateSigningKeyParams, DeleteSigningKeyParams, GetSigningKeyParams,
@@ -12,20 +12,23 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_signing_key() {
+    let mut server = Server::new_async().await;
     let organization_prn = "org-1";
     let expected_value = "a";
     let expected_name = "b";
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*format!("/signing_keys"))
+    let m = server
+        .mock("POST", &*format!("/signing_keys"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/signing-keys-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateSigningKeyParams {
         value: expected_value.to_string(),
@@ -44,22 +47,25 @@ async fn create_signing_key() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn delete_signing_key() {
+    let mut server = Server::new_async().await;
     let signing_key_prn = "b";
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("DELETE", &*format!("/signing_keys/{signing_key_prn}"))
+    let m = server
+        .mock("DELETE", &*format!("/signing_keys/{signing_key_prn}"))
         .with_status(204)
         .with_body("")
-        .create();
+        .create_async()
+        .await;
 
     let params = DeleteSigningKeyParams {
         signing_key_prn: signing_key_prn.to_string(),
@@ -70,25 +76,28 @@ async fn delete_signing_key() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_signing_key() {
+    let mut server = Server::new_async().await;
     let signing_key_prn = "b";
     let expected_value = "a";
     let expected_name = "b";
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/signing_keys/{signing_key_prn}"))
+    let m = server
+        .mock("GET", &*format!("/signing_keys/{signing_key_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/signing-keys-get-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = GetSigningKeyParams {
         prn: signing_key_prn.to_string(),
@@ -105,5 +114,5 @@ async fn get_signing_key() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/tunnels.rs
+++ b/tests/tunnels.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 
 use peridio_sdk::api::tunnels::{CreateTunnelParams, GetTunnelParams, UpdateTunnelParams};
 
@@ -10,6 +10,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_tunnel() {
+    let mut server = Server::new_async().await;
     let cidr_block_allowlist = ["10.0.0.1/32".to_string()].to_vec();
     let device_prn = "device_prn";
     let port = 22;
@@ -17,15 +18,17 @@ async fn create_tunnel() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*format!("/tunnels"))
+    let m = server
+        .mock("POST", &*format!("/tunnels"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/tunnels-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateTunnelParams {
         cidr_block_allowlist: Some(cidr_block_allowlist.clone()),
@@ -50,11 +53,12 @@ async fn create_tunnel() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_tunnel() {
+    let mut server = Server::new_async().await;
     let expected_state = "requested";
     let expected_server_proxy_port = 49293;
     let expected_device_prn = "device_prn";
@@ -63,15 +67,17 @@ async fn get_tunnel() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/tunnels/{expected_prn}"))
+    let m = server
+        .mock("GET", &*format!("/tunnels/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/tunnels-get-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = GetTunnelParams {
         prn: expected_prn.to_string(),
@@ -93,25 +99,28 @@ async fn get_tunnel() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_tunnel() {
+    let mut server = Server::new_async().await;
     let expected_state = "closed";
     let expected_prn = "1";
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("PATCH", &*format!("/tunnels/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/tunnels/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/tunnels-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateTunnelParams {
         prn: expected_prn.to_string(),
@@ -130,5 +139,5 @@ async fn update_tunnel() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/unauthenticated.rs
+++ b/tests/unauthenticated.rs
@@ -1,26 +1,29 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 use peridio_sdk::api::Api;
 use peridio_sdk::api::ApiOptions;
 use peridio_sdk::api::Error::Unknown;
 
 #[tokio::test]
 async fn bad_params() {
-    let m = mock("GET", "/users/me")
+    let mut server = Server::new_async().await;
+    let m = server
+        .mock("GET", "/users/me")
         .with_status(403)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/403.json")
-        .create();
+        .create_async()
+        .await;
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
     let result = api.users().me().await;
     assert!(matches!(result, Err(Unknown { .. })));
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,25 +1,28 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 use peridio_sdk::api::Api;
 use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn get_users_me_api() {
+    let mut server = Server::new_async().await;
     let expected_email = "a@b.com";
     let expected_username = "c";
     let path = "/users/me".to_string();
 
-    let m = mock("GET", &*path)
+    let m = server
+        .mock("GET", &*path)
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/users-me-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
@@ -31,5 +34,5 @@ async fn get_users_me_api() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }

--- a/tests/webhooks.rs
+++ b/tests/webhooks.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::API_KEY;
-use mockito::{mock, server_url as mock_server_url};
+use mockito::Server;
 use peridio_sdk::api::webhooks::CreateWebhookParams;
 use peridio_sdk::api::webhooks::GetWebhookParams;
 use peridio_sdk::api::webhooks::UpdateWebhookParams;
@@ -10,6 +10,7 @@ use peridio_sdk::api::ApiOptions;
 
 #[tokio::test]
 async fn create_webhook() {
+    let mut server = Server::new_async().await;
     let expected_url = "https://peridio.com";
     let expected_state = "disabled";
     let expected_description = "description";
@@ -18,15 +19,17 @@ async fn create_webhook() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("POST", &*format!("/webhooks"))
+    let m = server
+        .mock("POST", &*format!("/webhooks"))
         .with_status(201)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/webhooks-create-201.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = CreateWebhookParams {
         description: Some(expected_description.to_string()),
@@ -48,11 +51,12 @@ async fn create_webhook() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn get_webhook() {
+    let mut server = Server::new_async().await;
     let expected_description = "description";
     let expected_prn = "prn";
     let expected_state = "enabled";
@@ -61,15 +65,17 @@ async fn get_webhook() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("GET", &*format!("/webhooks/{expected_prn}"))
+    let m = server
+        .mock("GET", &*format!("/webhooks/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/webhooks-get-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = GetWebhookParams {
         prn: expected_prn.to_string(),
@@ -88,11 +94,12 @@ async fn get_webhook() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }
 
 #[tokio::test]
 async fn update_webhook() {
+    let mut server = Server::new_async().await;
     let expected_description = "description";
     let expected_prn = "prn";
     let expected_url = "https://peridio.com";
@@ -101,15 +108,17 @@ async fn update_webhook() {
 
     let api = Api::new(ApiOptions {
         api_key: API_KEY.into(),
-        endpoint: Some(mock_server_url()),
+        endpoint: Some(server.url()),
         ca_bundle_path: None,
     });
 
-    let m = mock("PATCH", &*format!("/webhooks/{expected_prn}"))
+    let m = server
+        .mock("PATCH", &*format!("/webhooks/{expected_prn}"))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body_from_file("tests/fixtures/webhooks-update-200.json")
-        .create();
+        .create_async()
+        .await;
 
     let params = UpdateWebhookParams {
         prn: expected_prn.to_string(),
@@ -132,5 +141,5 @@ async fn update_webhook() {
         _ => panic!(),
     }
 
-    m.assert();
+    m.assert_async().await;
 }


### PR DESCRIPTION
This is a major version bump that requires notable changes to the setup of peridio-rust's tests:

- Use async methods.
- Update imports and call-sites to only use mockito::Server.