### PR TITLE
support bavarb deletion

### DIFF
--- a/src/api/artifact_versions.rs
+++ b/src/api/artifact_versions.rs
@@ -50,6 +50,14 @@ pub struct GetArtifactVersionResponse {
 }
 
 #[derive(Debug, Serialize)]
+pub struct DeleteArtifactVersionParams {
+    pub prn: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteArtifactVersionResponse {}
+
+#[derive(Debug, Serialize)]
 pub struct ListArtifactVersionsParams {
     pub limit: Option<u8>,
     pub order: Option<String>,
@@ -99,6 +107,20 @@ impl<'a> ArtifactVersionsApi<'a> {
             }
             Err(err) => Err(err),
         }
+    }
+
+    pub async fn delete(
+        &'a self,
+        params: DeleteArtifactVersionParams,
+    ) -> Result<Option<DeleteArtifactVersionResponse>, Error> {
+        let artifact_version_prn: String = params.prn;
+        self.0
+            .execute(
+                Method::DELETE,
+                format!("/artifact_versions/{artifact_version_prn}"),
+                None,
+            )
+            .await
     }
 
     pub async fn get(

--- a/src/api/artifacts.rs
+++ b/src/api/artifacts.rs
@@ -49,6 +49,14 @@ pub struct GetArtifactResponse {
 }
 
 #[derive(Debug, Serialize)]
+pub struct DeleteArtifactParams {
+    pub prn: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteArtifactResponse {}
+
+#[derive(Debug, Serialize)]
 pub struct ListArtifactsParams {
     pub limit: Option<u8>,
     pub order: Option<String>,
@@ -97,6 +105,16 @@ impl<'a> ArtifactsApi<'a> {
             }
             Err(err) => Err(err),
         }
+    }
+
+    pub async fn delete(
+        &'a self,
+        params: DeleteArtifactParams,
+    ) -> Result<Option<DeleteArtifactResponse>, Error> {
+        let artifact_prn: String = params.prn;
+        self.0
+            .execute(Method::DELETE, format!("/artifacts/{artifact_prn}"), None)
+            .await
     }
 
     pub async fn get(

--- a/src/api/binaries.rs
+++ b/src/api/binaries.rs
@@ -86,6 +86,14 @@ pub struct GetBinaryParams {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteBinaryParams {
+    pub prn: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteBinaryResponse {}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct GetBinaryResponse {
     pub binary: Binary,
 }
@@ -145,6 +153,16 @@ impl<'a> BinariesApi<'a> {
             }
             Err(err) => Err(err),
         }
+    }
+
+    pub async fn delete(
+        &'a self,
+        params: DeleteBinaryParams,
+    ) -> Result<Option<DeleteBinaryResponse>, Error> {
+        let binary_prn: String = params.prn;
+        self.0
+            .execute(Method::DELETE, format!("/binaries/{binary_prn}"), None)
+            .await
     }
 
     pub async fn get(

--- a/src/api/bundles.rs
+++ b/src/api/bundles.rs
@@ -42,6 +42,14 @@ pub struct GetBundleResponse {
 }
 
 #[derive(Debug, Serialize)]
+pub struct DeleteBundleParams {
+    pub prn: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteBundleResponse {}
+
+#[derive(Debug, Serialize)]
 pub struct ListBundlesParams {
     pub limit: Option<u8>,
     pub order: Option<String>,
@@ -77,6 +85,16 @@ impl<'a> BundlesApi<'a> {
     ) -> Result<Option<CreateBundleResponse>, Error> {
         self.0
             .execute(Method::POST, "/bundles", Some(json_body!(&params)))
+            .await
+    }
+
+    pub async fn delete(
+        &'a self,
+        params: DeleteBundleParams,
+    ) -> Result<Option<DeleteBundleResponse>, Error> {
+        let bundle_prn: String = params.prn;
+        self.0
+            .execute(Method::DELETE, format!("/bundles/{bundle_prn}"), None)
             .await
     }
 

--- a/src/api/releases.rs
+++ b/src/api/releases.rs
@@ -76,6 +76,13 @@ pub struct GetReleaseResponse {
 }
 
 #[derive(Debug, Serialize)]
+pub struct DeleteReleaseParams {
+    pub prn: String,
+}
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteReleaseResponse {}
+
+#[derive(Debug, Serialize)]
 pub struct ListReleasesParams {
     pub limit: Option<u8>,
     pub order: Option<String>,
@@ -151,6 +158,16 @@ impl<'a> ReleasesApi<'a> {
         let release_prn: String = params.prn;
         self.0
             .execute(Method::GET, format!("/releases/{release_prn}"), None)
+            .await
+    }
+
+    pub async fn delete(
+        &'a self,
+        params: DeleteReleaseParams,
+    ) -> Result<Option<DeleteReleaseResponse>, Error> {
+        let release_prn: String = params.prn;
+        self.0
+            .execute(Method::DELETE, format!("/releases/{release_prn}"), None)
             .await
     }
 

--- a/tests/artifact_versions.rs
+++ b/tests/artifact_versions.rs
@@ -4,7 +4,8 @@ use common::API_KEY;
 use mockito::Server;
 
 use peridio_sdk::api::artifact_versions::{
-    CreateArtifactVersionParams, GetArtifactVersionParams, UpdateArtifactVersionParams,
+    CreateArtifactVersionParams, DeleteArtifactVersionParams, GetArtifactVersionParams,
+    UpdateArtifactVersionParams,
 };
 
 use peridio_sdk::api::Api;
@@ -92,6 +93,36 @@ async fn create_artifact_version() {
     }
 
     m.expect(0);
+}
+
+#[tokio::test]
+async fn delete_artifact_version() {
+    let mut server = Server::new_async().await;
+    let expected_prn = "prn";
+
+    let api = Api::new(ApiOptions {
+        api_key: API_KEY.into(),
+        endpoint: Some(server.url()),
+        ca_bundle_path: None,
+    });
+
+    let m = server
+        .mock("DELETE", &*format!("/artifact_versions/{expected_prn}"))
+        .with_status(204)
+        .with_header("content-type", "application/json")
+        .create_async()
+        .await;
+
+    let params = DeleteArtifactVersionParams {
+        prn: expected_prn.to_string(),
+    };
+
+    match api.artifact_versions().delete(params).await.unwrap() {
+        None => (),
+        _ => panic!(),
+    }
+
+    m.assert_async().await;
 }
 
 #[tokio::test]

--- a/tests/artifacts.rs
+++ b/tests/artifacts.rs
@@ -3,7 +3,9 @@ mod common;
 use common::API_KEY;
 use mockito::Server;
 
-use peridio_sdk::api::artifacts::{CreateArtifactParams, GetArtifactParams, UpdateArtifactParams};
+use peridio_sdk::api::artifacts::{
+    CreateArtifactParams, DeleteArtifactParams, GetArtifactParams, UpdateArtifactParams,
+};
 
 use peridio_sdk::api::{Api, ApiOptions};
 use serde_json::json;
@@ -86,6 +88,36 @@ async fn create_artifact() {
     }
 
     m.expect(0);
+}
+
+#[tokio::test]
+async fn delete_artifact() {
+    let mut server = Server::new_async().await;
+    let expected_prn = "prn";
+
+    let api = Api::new(ApiOptions {
+        api_key: API_KEY.into(),
+        endpoint: Some(server.url()),
+        ca_bundle_path: None,
+    });
+
+    let m = server
+        .mock("DELETE", &*format!("/artifacts/{expected_prn}"))
+        .with_status(204)
+        .with_header("content-type", "application/json")
+        .create_async()
+        .await;
+
+    let params = DeleteArtifactParams {
+        prn: expected_prn.to_string(),
+    };
+
+    match api.artifacts().delete(params).await.unwrap() {
+        None => (),
+        _ => panic!(),
+    }
+
+    m.assert_async().await;
 }
 
 #[tokio::test]

--- a/tests/binaries.rs
+++ b/tests/binaries.rs
@@ -4,7 +4,7 @@ use common::API_KEY;
 use mockito::Server;
 
 use peridio_sdk::api::binaries::{
-    BinaryState, CreateBinaryParams, GetBinaryParams, UpdateBinaryParams,
+    BinaryState, CreateBinaryParams, DeleteBinaryParams, GetBinaryParams, UpdateBinaryParams,
 };
 
 use peridio_sdk::api::Api;
@@ -102,6 +102,36 @@ async fn create_binary() {
     }
 
     m.expect(0);
+}
+
+#[tokio::test]
+async fn delete_binary() {
+    let mut server = Server::new_async().await;
+    let expected_prn = "prn";
+
+    let api = Api::new(ApiOptions {
+        api_key: API_KEY.into(),
+        endpoint: Some(server.url()),
+        ca_bundle_path: None,
+    });
+
+    let m = server
+        .mock("DELETE", &*format!("/binaries/{expected_prn}"))
+        .with_status(204)
+        .with_header("content-type", "application/json")
+        .create_async()
+        .await;
+
+    let params = DeleteBinaryParams {
+        prn: expected_prn.to_string(),
+    };
+
+    match api.binaries().delete(params).await.unwrap() {
+        None => (),
+        _ => panic!(),
+    }
+
+    m.assert_async().await;
 }
 
 #[tokio::test]

--- a/tests/bundles.rs
+++ b/tests/bundles.rs
@@ -3,7 +3,9 @@ mod common;
 use common::API_KEY;
 use mockito::Server;
 
-use peridio_sdk::api::bundles::{CreateBundleParams, GetBundleParams, UpdateBundleParams};
+use peridio_sdk::api::bundles::{
+    CreateBundleParams, DeleteBundleParams, GetBundleParams, UpdateBundleParams,
+};
 
 use peridio_sdk::api::Api;
 use peridio_sdk::api::ApiOptions;
@@ -50,6 +52,36 @@ async fn create_bundle() {
 
             assert_eq!(bundle.bundle.artifact_versions, expected_artifact_versions);
         }
+        _ => panic!(),
+    }
+
+    m.assert_async().await;
+}
+
+#[tokio::test]
+async fn delete_bundle() {
+    let mut server = Server::new_async().await;
+    let expected_prn = "prn";
+
+    let api = Api::new(ApiOptions {
+        api_key: API_KEY.into(),
+        endpoint: Some(server.url()),
+        ca_bundle_path: None,
+    });
+
+    let m = server
+        .mock("DELETE", &*format!("/bundles/{expected_prn}"))
+        .with_status(204)
+        .with_header("content-type", "application/json")
+        .create_async()
+        .await;
+
+    let params = DeleteBundleParams {
+        prn: expected_prn.to_string(),
+    };
+
+    match api.bundles().delete(params).await.unwrap() {
+        None => (),
         _ => panic!(),
     }
 

--- a/tests/releases.rs
+++ b/tests/releases.rs
@@ -3,7 +3,9 @@ mod common;
 use common::API_KEY;
 use mockito::Server;
 
-use peridio_sdk::api::releases::{CreateReleaseParams, GetReleaseParams, UpdateReleaseParams};
+use peridio_sdk::api::releases::{
+    CreateReleaseParams, DeleteReleaseParams, GetReleaseParams, UpdateReleaseParams,
+};
 
 use peridio_sdk::api::Api;
 use peridio_sdk::api::ApiOptions;
@@ -85,6 +87,36 @@ async fn create_release() {
                 Some(expected_version_requirement.to_string())
             );
         }
+        _ => panic!(),
+    }
+
+    m.assert_async().await;
+}
+
+#[tokio::test]
+async fn delete_release() {
+    let mut server = Server::new_async().await;
+    let expected_prn = "prn";
+
+    let api = Api::new(ApiOptions {
+        api_key: API_KEY.into(),
+        endpoint: Some(server.url()),
+        ca_bundle_path: None,
+    });
+
+    let m = server
+        .mock("DELETE", &*format!("/releases/{expected_prn}"))
+        .with_status(204)
+        .with_header("content-type", "application/json")
+        .create_async()
+        .await;
+
+    let params = DeleteReleaseParams {
+        prn: expected_prn.to_string(),
+    };
+
+    match api.releases().delete(params).await.unwrap() {
+        None => (),
         _ => panic!(),
     }
 


### PR DESCRIPTION
This adds admin http api operations for deletion of:
- binaries
- bundles
- releases
- artifact versions
- artifacts